### PR TITLE
Add Foldable1 instance for FastVect

### DIFF
--- a/src/Data/FastVect/FastVect.purs
+++ b/src/Data/FastVect/FastVect.purs
@@ -14,6 +14,7 @@ module Data.FastVect.FastVect
   , head
   , fromArray
   , toArray
+  , toNonEmptyArray
   , adjust
   , adjustM
   , cons
@@ -26,6 +27,8 @@ import Prelude
 
 import Data.Array as A
 import Data.Array as Array
+import Data.Array.NonEmpty as NEA
+import Data.Array.NonEmpty.Internal (NonEmptyArray(NonEmptyArray))
 import Data.FastVect.Common as Common
 import Data.Foldable (class Foldable)
 import Data.FoldableWithIndex (class FoldableWithIndex)
@@ -33,6 +36,7 @@ import Data.FunctorWithIndex (class FunctorWithIndex)
 import Data.Maybe (Maybe(..))
 import Data.Ord (abs)
 import Data.Reflectable (class Reflectable)
+import Data.Semigroup.Foldable as Foldable1
 import Data.Traversable (class Traversable)
 import Data.TraversableWithIndex (class TraversableWithIndex)
 import Prim.Int (class Compare)
@@ -63,6 +67,12 @@ instance (Compare len Common.NegOne GT, Reflectable len Int) ⇒ Applicative (Ve
 derive newtype instance FunctorWithIndex Int (Vect len)
 derive newtype instance Foldable (Vect len)
 derive newtype instance FoldableWithIndex Int (Vect len)
+
+instance (Compare len Common.Zero GT) ⇒ Foldable1.Foldable1 (Vect len) where
+  foldMap1 f xs = Foldable1.foldMap1 f $ toNonEmptyArray xs
+  foldr1 f xs = Foldable1.foldr1 f $ toNonEmptyArray xs
+  foldl1 f xs = Foldable1.foldl1 f $ toNonEmptyArray xs
+
 derive newtype instance Traversable (Vect len)
 derive newtype instance TraversableWithIndex Int (Vect len)
 
@@ -239,6 +249,14 @@ toArray
   ⇒ Vect len elem
   → Array elem
 toArray (Vect arr) = arr
+
+-- -- | Converts the `Vect` to an `NonEmptyArray`, dropping most of the size information.
+toNonEmptyArray
+  ∷ ∀ len elem
+  . Compare len Common.Zero GT
+  ⇒ Vect len elem
+  → NEA.NonEmptyArray elem
+toNonEmptyArray (Vect arr) = NonEmptyArray arr
 
 -- -- | Creates a `Vect` by adjusting the given `Array`, padding with the provided element if the array is to small or dropping elements if the array is to big.
 -- -- |

--- a/test/Data/FastVect/FastVectSpec.purs
+++ b/test/Data/FastVect/FastVectSpec.purs
@@ -7,6 +7,7 @@ import Data.FastVect.Common as C
 import Data.FastVect.Sparse.Read as FVR
 import Data.FastVect.Sparse.Write as FVW
 import Data.Foldable (foldl)
+import Data.Semigroup.Foldable (foldl1, foldr1)
 import Data.Map as Map
 import Data.Maybe (Maybe(..))
 import Data.Traversable (traverse)
@@ -39,6 +40,8 @@ spec =
           let
             vect = FV.cons 1 $ FV.cons 2 $ FV.cons 3 $ FV.cons 4 FV.empty
           (foldl (+) 0 vect) `shouldEqual` 10
+          (foldl1 (+) vect) `shouldEqual` 10
+          (foldr1 (+) vect) `shouldEqual` 10
           (FV.head vect) `shouldEqual` 1
           --(head empty) `shouldEqual` 1 -- should not compile
           (FV.index (C.term :: _ 0) vect) `shouldEqual` 1


### PR DESCRIPTION
This PR partially addresses #6 by endowing `FastVect` with a `Foldable1` instance but does nothing for `Sparse.Read` or `Sparse.Write`. Works by converting the `FastVect` to a `NonEmptyArray`, so you get a `toNonEmptyArray` function for free.