### PR TITLE
Fix pursuit link

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Further functions that are defined differently to the `Array` functions are:
 * `take` is guaranteed to return you a vector with the number of elements requested and result in a compile-time error if you are trying to request more elements than are in the vector. 
 * `drop` is guaranteed to drop the exact number of elements from the vector and result in a compile-time error if you are trying to drop more elements than exist in the vector.
 
-You can find the full api on [pursuit](https://pursuit.purescript.org/packages/purescript-fast-vect/latest/docs/Data.FastVect.FastVect). 
+You can find the full api on [pursuit](https://pursuit.purescript.org/packages/purescript-fast-vect/docs/Data.FastVect.FastVect). 
 
 ## Example usage 
 


### PR DESCRIPTION
`latest/` does not seem to work, but simply skipping the version will cause a redirect.