### PR TITLE
Add more numeric instances

### DIFF
--- a/src/Data/FastVect/FastVect.purs
+++ b/src/Data/FastVect/FastVect.purs
@@ -120,6 +120,14 @@ instance (Compare len Common.NegOne GT, Reflectable len Int, Ring a) => Ring (Ve
 
 instance (Compare len Common.NegOne GT, Reflectable len Int, CommutativeRing a) => CommutativeRing (Vect len a)
 
+instance (Compare len Common.NegOne GT, Reflectable len Int, EuclideanRing a) => EuclideanRing (Vect len a) where
+  div = lift2 div
+  mod = lift2 mod
+  degree = const 1
+
+instance (Compare len Common.NegOne GT, Reflectable len Int, DivisionRing a) => DivisionRing (Vect len a) where
+  recip = map recip
+
 -- | Create a `Vect` by replicating `len` times the given element
 -- |
 -- | ```

--- a/src/Data/FastVect/FastVect/Matrix.purs
+++ b/src/Data/FastVect/FastVect/Matrix.purs
@@ -123,6 +123,14 @@ instance (Compare h Common.NegOne GT, Reflectable h Int, Compare w Common.NegOne
 
 instance (Compare h Common.NegOne GT, Reflectable h Int, Compare w Common.NegOne GT, Reflectable w Int, CommutativeRing a) => CommutativeRing (Matrix h w a)
 
+instance (Compare h Common.NegOne GT, Reflectable h Int, Compare w Common.NegOne GT, Reflectable w Int, EuclideanRing a) => EuclideanRing (Matrix h w a) where
+  div = lift2 div
+  mod = lift2 mod
+  degree = const 1
+
+instance (Compare h Common.NegOne GT, Reflectable h Int, Compare w Common.NegOne GT, Reflectable w Int, DivisionRing a) => DivisionRing (Matrix h w a) where
+  recip = map recip
+
 -- | Safely accesses the `j` -th element of the `i` -th row of `Matrix`.
 index :: forall h w i j elem. CommonM.Index Matrix h w i j elem
 index _ _ (Matrix m) = V.index (Common.term :: _ i) $ V.index (Common.term :: _ j) m

--- a/src/Data/FastVect/MinLenVect.purs
+++ b/src/Data/FastVect/MinLenVect.purs
@@ -127,6 +127,13 @@ instance (Compare len Common.NegOne GT, Reflectable len Int, Ring a) => Ring (Mi
 
 instance (Compare len Common.NegOne GT, Reflectable len Int, CommutativeRing a) => CommutativeRing (MinLenVect len a)
 
+instance (Compare len Common.NegOne GT, Reflectable len Int, EuclideanRing a) => EuclideanRing (MinLenVect len a) where
+  div = lift2 div
+  mod = lift2 mod
+  degree = const 1
+
+instance (Compare len Common.NegOne GT, Reflectable len Int, DivisionRing a) => DivisionRing (MinLenVect len a) where
+  recip = map recip
 
 -- | Create a `MinLenVect` by replicating `len` times the given element
 -- |

--- a/test/Data/FastVect/FastVectSpec/MatrixSpec.purs
+++ b/test/Data/FastVect/FastVectSpec/MatrixSpec.purs
@@ -173,3 +173,19 @@ spec =
             actualDiagMatrix = FM.diag vect
 
           actualDiagMatrix `shouldEqual` expectedDiagMatrix
+
+        it "should successfully evaluate component-wise division" do
+          let
+            matrix :: FM.Matrix 2 2 Int
+            matrix = FM.Matrix $ (1 : 2 : FV.empty) : (3 : 4 : FV.empty) : FV.empty
+
+            matrix2 :: FM.Matrix 2 2 Int
+            matrix2 = FM.Matrix $ (5 : 6 : FV.empty) : (7 : 8 : FV.empty) : FV.empty
+
+            expected :: FM.Matrix 2 2 Int
+            expected = FM.Matrix $ (1 / 5 : 2 / 6 : FV.empty) : (3 / 7 : 4 / 8 : FV.empty) : FV.empty
+
+            actual :: FM.Matrix 2 2 Int
+            actual = matrix / matrix2
+
+          actual `shouldEqual` expected


### PR DESCRIPTION
This commit adds some missing numeric type class instances (`EuclideanRing` and `DivisionRing`) for `FastVect`, `MinLenVect`, and `Matrix`.

These are all component-wise operations matching the existing type class instances. I don't know if that might be unexpected for `Matrix`, but I've added a test case to help clarify the behavior.

Closes #29 